### PR TITLE
Mkr1: Реалізація шаблону 'Ітератор' для обходу HTML-дерева в глибину та ширину

### DIFF
--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/BreadthFirstIterator.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/BreadthFirstIterator.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Iterators
+{
+    public class BreadthFirstIterator : ILightNodeIterator
+    {
+        private readonly Queue<LightNode> _pendingNodes = new Queue<LightNode>();
+        private readonly HashSet<LightNode> _visitedNodes = new HashSet<LightNode>();
+        private readonly LightNode _startNode;
+        private LightNode _current;
+
+        public BreadthFirstIterator(LightNode startNode)
+        {
+            _startNode = startNode ?? throw new ArgumentNullException(nameof(startNode));
+            _pendingNodes.Enqueue(_startNode);
+        }
+
+        public bool MoveNext()
+        {
+            while (_pendingNodes.Count > 0)
+            {
+                var candidate = _pendingNodes.Dequeue();
+
+                if (_visitedNodes.Contains(candidate))
+                    continue;
+
+                _visitedNodes.Add(candidate);
+                _current = candidate;
+
+                EnqueueChildren(candidate);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public LightNode Current => _current;
+
+        public void Reset()
+        {
+            _pendingNodes.Clear();
+            _visitedNodes.Clear();
+            if (_startNode != null)
+                _pendingNodes.Enqueue(_startNode);
+            _current = null;
+        }
+
+        private void EnqueueChildren(LightNode node)
+        {
+            if (node is LightElementNode element && element.Children != null)
+            {
+                foreach (var child in element.Children)
+                {
+                    if (!_visitedNodes.Contains(child))
+                        _pendingNodes.Enqueue(child);
+                }
+            }
+        }
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/DepthFirstIterator.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/DepthFirstIterator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Iterators
+{
+    public class DepthFirstIterator : ILightNodeIterator
+    {
+        private readonly Stack<LightNode> _pendingNodes = new Stack<LightNode>();
+        private readonly LightNode _startNode;
+        private LightNode _currentNode;
+
+        public DepthFirstIterator(LightNode root)
+        {
+            _startNode = root ?? throw new ArgumentNullException(nameof(root));
+            _pendingNodes.Push(_startNode);
+        }
+
+        public bool MoveNext()
+        {
+            if (_pendingNodes.Count == 0)
+                return false;
+
+            _currentNode = _pendingNodes.Pop();
+
+            PushChildren(_currentNode);
+
+            return true;
+        }
+
+        public LightNode Current => _currentNode;
+
+        public void Reset()
+        {
+            _pendingNodes.Clear();
+            if (_startNode != null)
+                _pendingNodes.Push(_startNode);
+            _currentNode = null;
+        }
+
+        private void PushChildren(LightNode node)
+        {
+            if (node is LightElementNode element && element.Children != null)
+            {
+                // у зворотному порядку для правильного DFS
+                for (int i = element.Children.Count - 1; i >= 0; i--)
+                {
+                    _pendingNodes.Push(element.Children[i]);
+                }
+            }
+        }
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/ILightNodeCollection.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/ILightNodeCollection.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Iterators
+{
+    public interface ILightNodeCollection
+    {
+        ILightNodeIterator CreateDepthIterator();
+        ILightNodeIterator CreateBreadthIterator();
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/ILightNodeIterator.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/ILightNodeIterator.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Iterators
+{
+    public interface ILightNodeIterator
+    {
+        bool MoveNext();              
+        LightNode Current { get; }   
+        void Reset();                
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightElementNode.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightElementNode.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CompositeLibrary.Iterators;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -17,7 +18,7 @@ namespace CompositeLibrary
         Double
     }
 
-    public class LightElementNode : LightNode
+    public class LightElementNode : LightNode, ILightNodeCollection
     {
         public string TagName { get; }
         public DisplayType Display { get; }
@@ -151,6 +152,16 @@ namespace CompositeLibrary
         public override int ChildElementsCount()
         {
             return Children.Count;
+        }
+
+        public ILightNodeIterator CreateDepthIterator()
+        {
+            return new DepthFirstIterator(this);
+        }
+
+        public ILightNodeIterator CreateBreadthIterator()
+        {
+            return new BreadthFirstIterator(this);
         }
     }
 }

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/App.config
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/ConsoleApp_MKR1_iterator.csproj
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/ConsoleApp_MKR1_iterator.csproj
@@ -4,16 +4,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FC09D211-DDDA-4C51-87C8-D7E3BD2153FA}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CompositeLibrary</RootNamespace>
-    <AssemblyName>CompositeLibrary</AssemblyName>
+    <ProjectGuid>{9D2989DE-13E6-4E5B-A88B-EEE5F5CC0A44}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ConsoleApp_MKR1_iterator</RootNamespace>
+    <AssemblyName>ConsoleApp_MKR1_iterator</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -41,20 +43,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ConsoleLoggerEventListener.cs" />
-    <Compile Include="IEventListener.cs" />
-    <Compile Include="Iterators\BreadthFirstIterator.cs" />
-    <Compile Include="Iterators\DepthFirstIterator.cs" />
-    <Compile Include="Iterators\ILightNodeCollection.cs" />
-    <Compile Include="Iterators\ILightNodeIterator.cs" />
-    <Compile Include="Lab4.4-stategy\FileImageLoadingStrategy.cs" />
-    <Compile Include="Lab4.4-stategy\IImageLoadingStrategy.cs" />
-    <Compile Include="Lab4.4-stategy\ImageNode.cs" />
-    <Compile Include="Lab4.4-stategy\NetworkImageLoadingStrategy.cs" />
-    <Compile Include="LightElementNode.cs" />
-    <Compile Include="LightNode.cs" />
-    <Compile Include="LightTextNode.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CompositeLibrary\CompositeLibrary.csproj">
+      <Project>{fc09d211-ddda-4c51-87c8-d7e3bd2153fa}</Project>
+      <Name>CompositeLibrary</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/Program.cs
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/Program.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CompositeLibrary;
+
+namespace ConsoleApp_MKR1_iterator
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.OutputEncoding = Encoding.UTF8;
+            Console.InputEncoding = Encoding.UTF8;
+
+            Console.WriteLine("=== DEMO: Ітератор ===\n");
+
+            // Побудова дерева HTML
+            var root = new LightElementNode("div", DisplayType.Block, ClosingType.Double);
+            root.AddCssClass("root");
+
+            var section = new LightElementNode("section", DisplayType.Block, ClosingType.Double);
+            section.AddCssClass("section");
+
+            var p1 = new LightElementNode("p", DisplayType.Block, ClosingType.Double);
+            p1.AddCssClass("paragraph");
+            p1.AddChild(new LightTextNode("Це перший абзац."));
+
+            var p2 = new LightElementNode("p", DisplayType.Block, ClosingType.Double);
+            p2.AddCssClass("paragraph");
+            p2.AddChild(new LightTextNode("Це другий абзац."));
+
+            section.AddChild(p1);
+            section.AddChild(p2);
+            root.AddChild(section);
+
+            // Обхід у глибину
+            Console.WriteLine("Depth-First Traversal:");
+            var depthIterator = root.CreateDepthIterator();
+            while (depthIterator.MoveNext())
+            {
+                var node = depthIterator.Current;
+                Console.WriteLine($"[DF] {node.OuterHtml()}");
+            }
+
+            Console.WriteLine();
+
+            // Обхід у ширину
+            Console.WriteLine("Breadth-First Traversal:");
+            var breadthIterator = root.CreateBreadthIterator();
+            while (breadthIterator.MoveNext())
+            {
+                var node = breadthIterator.Current;
+                Console.WriteLine($"[BF] {node.OuterHtml()}");
+            }
+
+            Console.WriteLine("\n=== Done ===");
+        }
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/Properties/AssemblyInfo.cs
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Общие сведения об этой сборке предоставляются следующим набором
+// набора атрибутов. Измените значения этих атрибутов для изменения сведений,
+// связанные с этой сборкой.
+[assembly: AssemblyTitle("ConsoleApp_MKR1_iterator")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConsoleApp_MKR1_iterator")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Установка значения False для параметра ComVisible делает типы в этой сборке невидимыми
+// для компонентов COM. Если необходимо обратиться к типу в этой сборке через
+// из модели COM задайте для атрибута ComVisible этого типа значение true.
+[assembly: ComVisible(false)]
+
+// Следующий GUID представляет идентификатор typelib, если этот проект доступен из модели COM
+[assembly: Guid("9d2989de-13e6-4e5b-a88b-eee5f5cc0a44")]
+
+// Сведения о версии сборки состоят из указанных ниже четырех значений:
+//
+//      Основной номер версии
+//      Дополнительный номер версии
+//      Номер сборки
+//      Номер редакции
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/lab3/task5-6-compositorLightHTML/task5-6-compositorLightHTML.sln
+++ b/lab3/task5-6-compositorLightHTML/task5-6-compositorLightHTML.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp-task6", "Console
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp-MKR1-template", "ConsoleApp-MKR1-template\ConsoleApp-MKR1-template.csproj", "{5C76C2D6-9AD2-4D3F-BEE1-92662AE43AB7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp_MKR1_iterator", "ConsoleApp_MKR1_iterator\ConsoleApp_MKR1_iterator.csproj", "{9D2989DE-13E6-4E5B-A88B-EEE5F5CC0A44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{5C76C2D6-9AD2-4D3F-BEE1-92662AE43AB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C76C2D6-9AD2-4D3F-BEE1-92662AE43AB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C76C2D6-9AD2-4D3F-BEE1-92662AE43AB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D2989DE-13E6-4E5B-A88B-EEE5F5CC0A44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D2989DE-13E6-4E5B-A88B-EEE5F5CC0A44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D2989DE-13E6-4E5B-A88B-EEE5F5CC0A44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D2989DE-13E6-4E5B-A88B-EEE5F5CC0A44}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
За допомогою шаблона "Ітератор"  реалізовано обхід DOM-дерева LightHTML.

[ILightNodeIterator](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/iterator/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/ILightNodeIterator.cs) - інтерфес ітератора з методами MoveNext(), Current, Reset(). Це дозволяє обійти вузли HTML-дерева без знання його внутрішньої структури, тобто інкапсулює логіку обходу.

[ILightNodeCollection](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/iterator/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/ILightNodeCollection.cs) - інтерфейс колекції вузлів, який дозволяє будь-якому вузлу реалізовувати підтримку обходу.

[DepthFirstIterator](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/iterator/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/DepthFirstIterator.cs) - обхід дерева в глибину за допомогою стеку. 

[BreadthFirstIterator](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/iterator/lab3/task5-6-compositorLightHTML/CompositeLibrary/Iterators/BreadthFirstIterator.cs) - обхід у ширину за допомогою черги. Додала HashSet, щоб уникнути повторного обходу.

Оновлено [LightElementNode](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/iterator/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightElementNode.cs#L157-L165). Додано методи CreateDepthIterator() та CreateBreadthIterator().

Створено демонстраційний проєкт [ConsoleApp_MKR1_iterator](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/iterator/lab3/task5-6-compositorLightHTML/ConsoleApp_MKR1_iterator/Program.cs)