### PR TITLE
Mkr1: Реалізація шаблону Visitor

### DIFF
--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Lab4.4-stategy/ImageNode.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Lab4.4-stategy/ImageNode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CompositeLibrary.Lab4._4_stategy;
+using CompositeLibrary.Visitor;
 
 namespace CompositeLibrary
 {
@@ -54,5 +55,7 @@ namespace CompositeLibrary
         public override void OnInserted() => Console.WriteLine("[Lifecycle] ImageNode inserted");
         public override void OnRemoved() => Console.WriteLine("[Lifecycle] ImageNode removed");
         public override void OnTextRendered() => Console.WriteLine("[Lifecycle] ImageNode rendered");
+
+        public override void Accept(ILightNodeVisitor visitor){}
     }
 }

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightElementNode.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightElementNode.cs
@@ -1,5 +1,6 @@
 ﻿using CompositeLibrary.Iterators;
 using CompositeLibrary.State;
+using CompositeLibrary.Visitor;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +31,6 @@ namespace CompositeLibrary
 
         private IVisibilityState _state = new VisibleState();
 
-        // Підтримка подій
         private readonly Dictionary<string, List<IEventListener>> eventListeners = new Dictionary<string, List<IEventListener>>();
 
         public LightElementNode(string tagName, DisplayType display, ClosingType closing)
@@ -177,6 +177,15 @@ namespace CompositeLibrary
         public override int ChildElementsCount()
         {
             return Children.Count;
+        }
+
+        public override void Accept(ILightNodeVisitor visitor)
+        {
+            visitor.VisitElement(this);
+            foreach (var child in Children)
+            {
+                child.Accept(visitor);
+            }
         }
 
         public ILightNodeIterator CreateDepthIterator()

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightNode.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightNode.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CompositeLibrary.Visitor;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,6 +12,7 @@ namespace CompositeLibrary
         public abstract string OuterHtml();
         public abstract string InnerHtml();
         public abstract int ChildElementsCount();
+        public abstract void Accept(ILightNodeVisitor visitor);
         public string Render()
         {
             OnCreated();

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightTextNode.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightTextNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CompositeLibrary.Visitor;
 
 namespace CompositeLibrary
 {
@@ -55,7 +56,15 @@ namespace CompositeLibrary
         // Життєві хуки (демо)
         public override void OnCreated() => Console.WriteLine("[Lifecycle] LightTextNode created");
         public override void OnInserted() => Console.WriteLine("[Lifecycle] LightTextNode inserted");
-        public override void OnTextSanitize() => Console.WriteLine("[Lifecycle] LightTextNode text sanitized");
+        public override void OnRemoved() => Console.WriteLine("[Lifecycle] LightTextNode removed");
+        public override void OnStylesApplied() => Console.WriteLine("[Lifecycle] No styles applied to LightTextNode");
+        public override void OnClassListApplied() => Console.WriteLine("[Lifecycle] No class list applied to LightTextNode");
         public override void OnTextRendered() => Console.WriteLine("[Lifecycle] LightTextNode text rendered");
+        public override void OnTextSanitize() => Console.WriteLine("[Lifecycle] LightTextNode text sanitized");
+
+        public override void Accept(ILightNodeVisitor visitor)
+        {
+            visitor.VisitText(this);
+        }
     }
 }

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/ILightNodeVisitor.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/ILightNodeVisitor.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Visitor
+{
+    public interface ILightNodeVisitor
+    {
+        void VisitElement(LightElementNode element);
+        void VisitText(LightTextNode text);
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/NodeCountVisitor.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/NodeCountVisitor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Visitor
+{
+    public class NodeCountVisitor : ILightNodeVisitor
+    {
+        public int ElementCount { get; private set; } = 0;
+        public int TextCount { get; private set; } = 0;
+
+        public void VisitElement(LightElementNode element)
+        {
+            ElementCount++;
+        }
+
+        public void VisitText(LightTextNode text)
+        {
+            TextCount++;
+        }
+
+        public void Report()
+        {
+            Console.WriteLine($"[Visitor] Element nodes: {ElementCount}");
+            Console.WriteLine($"[Visitor] Text nodes: {TextCount}");
+        }
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/TextCollectorVisitor.cs
+++ b/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/TextCollectorVisitor.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompositeLibrary.Visitor
+{
+    public class TextCollectorVisitor : ILightNodeVisitor
+    {
+        private readonly StringBuilder _textBuilder = new StringBuilder();
+
+        public void VisitElement(LightElementNode element)
+        {
+            // Нічого не робимо для тегів
+        }
+
+        public void VisitText(LightTextNode text)
+        {
+            _textBuilder.Append(text.Text + " ");
+        }
+
+        public string GetCollectedText()
+        {
+            return _textBuilder.ToString().Trim();
+        }
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/App.config
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/ConsoleApp-MKR1-visitor.csproj
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/ConsoleApp-MKR1-visitor.csproj
@@ -4,16 +4,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FC09D211-DDDA-4C51-87C8-D7E3BD2153FA}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CompositeLibrary</RootNamespace>
-    <AssemblyName>CompositeLibrary</AssemblyName>
+    <ProjectGuid>{0FE70520-A829-41D8-A7AE-34767A185186}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ConsoleApp_MKR1_visitor</RootNamespace>
+    <AssemblyName>ConsoleApp-MKR1-visitor</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -41,32 +43,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Command\AddChildCommand.cs" />
-    <Compile Include="Command\AddClassCommand.cs" />
-    <Compile Include="Command\ChangeTextCommand.cs" />
-    <Compile Include="Command\CommandHistory.cs" />
-    <Compile Include="Command\ICommand.cs" />
-    <Compile Include="ConsoleLoggerEventListener.cs" />
-    <Compile Include="IEventListener.cs" />
-    <Compile Include="Iterators\BreadthFirstIterator.cs" />
-    <Compile Include="Iterators\DepthFirstIterator.cs" />
-    <Compile Include="Iterators\ILightNodeCollection.cs" />
-    <Compile Include="Iterators\ILightNodeIterator.cs" />
-    <Compile Include="Lab4.4-stategy\FileImageLoadingStrategy.cs" />
-    <Compile Include="Lab4.4-stategy\IImageLoadingStrategy.cs" />
-    <Compile Include="Lab4.4-stategy\ImageNode.cs" />
-    <Compile Include="Lab4.4-stategy\NetworkImageLoadingStrategy.cs" />
-    <Compile Include="LightElementNode.cs" />
-    <Compile Include="LightNode.cs" />
-    <Compile Include="LightTextNode.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="State\HiddenState.cs" />
-    <Compile Include="State\IVisibilityState.cs" />
-    <Compile Include="State\RemovedState.cs" />
-    <Compile Include="State\VisibleState.cs" />
-    <Compile Include="Visitor\ILightNodeVisitor.cs" />
-    <Compile Include="Visitor\NodeCountVisitor.cs" />
-    <Compile Include="Visitor\TextCollectorVisitor.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CompositeLibrary\CompositeLibrary.csproj">
+      <Project>{fc09d211-ddda-4c51-87c8-d7e3bd2153fa}</Project>
+      <Name>CompositeLibrary</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/Program.cs
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/Program.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CompositeLibrary;
+using CompositeLibrary.Visitor;
+
+namespace ConsoleApp_MKR1_visitor
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.OutputEncoding = Encoding.UTF8;
+            Console.WriteLine("=== Demo: Відвідувач ===\n");
+
+            var root = new LightElementNode("div", DisplayType.Block, ClosingType.Double);
+            root.AddCssClass("container");
+
+            var header = new LightElementNode("h1", DisplayType.Block, ClosingType.Double);
+            header.AddChild(new LightTextNode("Заголовок сторінки"));
+
+            var paragraph = new LightElementNode("p", DisplayType.Block, ClosingType.Double);
+            paragraph.AddCssClass("description");
+            paragraph.AddChild(new LightTextNode("Це текстовий блок з описом."));
+
+            root.AddChild(header);
+            root.AddChild(paragraph);
+
+            Console.WriteLine("HTML structure:");
+            Console.WriteLine(root.OuterHtml());
+
+            var textVisitor = new TextCollectorVisitor();
+            root.Accept(textVisitor);
+
+            Console.WriteLine("\nCollected Text:");
+            Console.WriteLine(textVisitor.GetCollectedText());
+
+            Console.WriteLine("\n=== Done ===");
+        }
+    }
+}

--- a/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/Properties/AssemblyInfo.cs
+++ b/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Общие сведения об этой сборке предоставляются следующим набором
+// набора атрибутов. Измените значения этих атрибутов для изменения сведений,
+// связанные с этой сборкой.
+[assembly: AssemblyTitle("ConsoleApp-MKR1-visitor")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConsoleApp-MKR1-visitor")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Установка значения False для параметра ComVisible делает типы в этой сборке невидимыми
+// для компонентов COM. Если необходимо обратиться к типу в этой сборке через
+// из модели COM задайте для атрибута ComVisible этого типа значение true.
+[assembly: ComVisible(false)]
+
+// Следующий GUID представляет идентификатор typelib, если этот проект доступен из модели COM
+[assembly: Guid("0fe70520-a829-41d8-a7ae-34767a185186")]
+
+// Сведения о версии сборки состоят из указанных ниже четырех значений:
+//
+//      Основной номер версии
+//      Дополнительный номер версии
+//      Номер сборки
+//      Номер редакции
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/lab3/task5-6-compositorLightHTML/task5-6-compositorLightHTML.sln
+++ b/lab3/task5-6-compositorLightHTML/task5-6-compositorLightHTML.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp-MKR1-command", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp-MKR1-state", "ConsoleApp-MKR1-state\ConsoleApp-MKR1-state.csproj", "{FA50771E-D214-47A7-AD38-7C9771191A05}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp-MKR1-visitor", "ConsoleApp-MKR1-visitor\ConsoleApp-MKR1-visitor.csproj", "{0FE70520-A829-41D8-A7AE-34767A185186}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{FA50771E-D214-47A7-AD38-7C9771191A05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA50771E-D214-47A7-AD38-7C9771191A05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FA50771E-D214-47A7-AD38-7C9771191A05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FE70520-A829-41D8-A7AE-34767A185186}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE70520-A829-41D8-A7AE-34767A185186}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FE70520-A829-41D8-A7AE-34767A185186}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FE70520-A829-41D8-A7AE-34767A185186}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Реалізовано шаблон проєктування Visitor, що дозволяє додавати нові операції над HTML-деревом без зміни класів вузлів. Основна мета — забезпечити гнучку і масштабовану логіку обробки вузлів шляхом делегування дій окремим відвідувачам.

[ILightNodeVisitor](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/visitor-pattern/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/ILightNodeVisitor.cs) - основа, яка дозволяє додавати нові дії без зміни LightNode:

- VisitElement(LightElementNode element) — обробка HTML-елементів.
- VisitText(LightTextNode text) — обробка текстових вузлів.

[Accept(ILightNodeVisitor)](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/visitor-pattern/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightNode.cs#L15) у LightNode - абстрактний метод для прийому відвідувача

[Accept()](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/visitor-pattern/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightElementNode.cs#L182-L189) у LightElementNode - рекурсивно викликає відвідувача на собі і на дочірніх вузлах

[Accept()](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/visitor-pattern/lab3/task5-6-compositorLightHTML/CompositeLibrary/LightTextNode.cs#L65-L68)  у LightTextNode - передає себе в VisitText(this)

[TextCollectorVisitor](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/visitor-pattern/lab3/task5-6-compositorLightHTML/CompositeLibrary/Visitor/TextCollectorVisitor.cs) - збирає усі текстові значення з LightTextNode в один рядок, що дозволяє витягнути весь текст сторінки

Демонстрація у [ConsoleApp_MKR1_visitor](https://github.com/sofia-maidaniuk/SoftwareDevelopment/blob/mkr1-feature/visitor-pattern/lab3/task5-6-compositorLightHTML/ConsoleApp-MKR1-visitor/Program.cs)